### PR TITLE
SO1S-252 Deploy Repository public 전환에 따른 ArgoCD Application 수정

### DIFF
--- a/apps/dev/app-backend.yaml
+++ b/apps/dev/app-backend.yaml
@@ -14,7 +14,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: main
     path: charts/backend
 

--- a/apps/dev/app-istio.yaml
+++ b/apps/dev/app-istio.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: main
     path: charts/istio
 

--- a/apps/dev/app-logging.yaml
+++ b/apps/dev/app-logging.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: main
     path: charts/logging
 

--- a/apps/dev/app-monitoring.yaml
+++ b/apps/dev/app-monitoring.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-dev
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: main
     path: charts/monitoring
 

--- a/apps/prod/app-backend.yaml
+++ b/apps/prod/app-backend.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/backend
 
@@ -23,8 +23,8 @@ spec:
     namespace: backend
 
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/prod/app-inference.yaml
+++ b/apps/prod/app-inference.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/inference
 

--- a/apps/prod/app-istio-base.yaml
+++ b/apps/prod/app-istio-base.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/istio/istio-base
 
@@ -23,8 +23,8 @@ spec:
     namespace: istio-system
 
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/prod/app-istio-gateway.yaml
+++ b/apps/prod/app-istio-gateway.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/istio/istio-gateway
 
@@ -23,8 +23,8 @@ spec:
     namespace: istio-system
 
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/prod/app-istiod.yaml
+++ b/apps/prod/app-istiod.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/istio/istiod
 
@@ -23,8 +23,8 @@ spec:
     namespace: istio-system
 
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/prod/app-logging.yaml
+++ b/apps/prod/app-logging.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/logging
 
@@ -23,8 +23,8 @@ spec:
     namespace: logging
 
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/prod/app-monitoring.yaml
+++ b/apps/prod/app-monitoring.yaml
@@ -9,7 +9,7 @@ spec:
   project: so1s-project-prod
 
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: charts/monitoring
 
@@ -23,8 +23,8 @@ spec:
     namespace: monitoring
 
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/root-dev.yaml
+++ b/root-dev.yaml
@@ -13,7 +13,7 @@ spec:
 
   # Source of the application manifests
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: main
     path: apps/dev
 

--- a/root-prod.yaml
+++ b/root-prod.yaml
@@ -13,7 +13,7 @@ spec:
 
   # Source of the application manifests
   source:
-    repoURL: git@github.com:So1S/deploy.git
+    repoURL: https://github.com/So1S/deploy.git
     targetRevision: release/v0.3.0
     path: apps/prod
 
@@ -21,11 +21,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: default
-  
+
   syncPolicy:
-    automated: 
-      prune: true 
-      selfHeal: true   
-    # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.  
+    automated:
+      prune: true
+      selfHeal: true
+    # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
# Deploy Repository public 전환에 따른 ArgoCD Application 수정

ssh 방식은 public으로 전환해도 계정 등록을 요구하기 때문에 ssh 방식의 repoURL을 HTTPS 방식으로 변경했습니다.

해당 PR 머지되면 테라폼 코드도 정상 동작할 예정입니다.

[인프라 테라폼 PR 링크](https://github.com/So1S/infra/pull/2)

## Tasks

- [x]  repoURL 수정


## Discussion


## Jira

- SO1S-252