### PR TITLE
SO1S-363 terraform dev 환경 자동화 istio ingress 오류

### DIFF
--- a/charts/istio/dev-values.yaml
+++ b/charts/istio/dev-values.yaml
@@ -1,3 +1,6 @@
+ingress:
+  enabled: false
+
 istio-gateway:
   tolerations:
     - key: kind

--- a/charts/istio/dev-values.yaml
+++ b/charts/istio/dev-values.yaml
@@ -1,3 +1,7 @@
+vender: "AWS" # AWS | on-premise
+
+environment: "develop"
+
 ingress:
   enabled: false
 

--- a/charts/istio/prod-values.yaml
+++ b/charts/istio/prod-values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  enabled: true

--- a/charts/istio/prod-values.yaml
+++ b/charts/istio/prod-values.yaml
@@ -1,2 +1,6 @@
+vender: "AWS" # AWS | on-premise
+
+environment: "production"
+
 ingress:
   enabled: true

--- a/charts/istio/prod-values.yaml
+++ b/charts/istio/prod-values.yaml
@@ -4,3 +4,13 @@ environment: "production"
 
 ingress:
   enabled: true
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
+    alb.ingress.kubernetes.io/healthcheck-port: "443"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:ap-northeast-2:089143290485:certificate/8f20bc85-876b-47a2-8c9f-27e9f5455ca9"
+    external-dns.alpha.kubernetes.io/hostname: "*.so1s.io"

--- a/charts/istio/templates/ingress.yaml
+++ b/charts/istio/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,3 +30,4 @@ spec:
               name: istio-gateway
               port:
                 number: 80
+{{ end -}}

--- a/charts/istio/templates/ingress.yaml
+++ b/charts/istio/templates/ingress.yaml
@@ -4,16 +4,10 @@ kind: Ingress
 metadata:
   name: istio-ingress
   namespace: istio-system
+ {{- if .Values.ingress.annotations }} 
   annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/target-type: instance
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
-    alb.ingress.kubernetes.io/healthcheck-port: '443'
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
-    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:ap-northeast-2:089143290485:certificate/8f20bc85-876b-47a2-8c9f-27e9f5455ca9"
-    external-dns.alpha.kubernetes.io/hostname: "*.so1s.io"
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
   defaultBackend:
     service:

--- a/charts/istio/values.yaml
+++ b/charts/istio/values.yaml
@@ -1,2 +1,5 @@
+ingress:
+  enabled: false
+
 istio-gateway: {}
 istiod: {}

--- a/charts/istio/values.yaml
+++ b/charts/istio/values.yaml
@@ -4,6 +4,7 @@ environment: "develop"
 
 ingress:
   enabled: false
+  annotations: {}
 
 istio-gateway: {}
 istiod: {}

--- a/charts/istio/values.yaml
+++ b/charts/istio/values.yaml
@@ -1,3 +1,7 @@
+vender: "AWS" # AWS | on-premise
+
+environment: "develop"
+
 ingress:
   enabled: false
 


### PR DESCRIPTION
# terraform dev 환경 자동화 istio ingress 오류

dev 환경 argocd 어플리케이션 프로비저닝 과정 중 istio ingress는 AWS 환경을 유지한 채로 생성됨

## Tasks

- [x]  ingress enabled 설정 생성
- [x]  vender, environment 설정 키 생성
- [x]  prod, dev yaml에 적용
- [x]  ingress 리팩토링

## Discussion

- environment가 dev일 경우에도 ingress를 사용할 여지가 있다고 생각하여 ingress.enabled 만으로 ingress 생성 여부를 끌 수 있도록 설정 했습니다.


## Jira

- SO1S-363