### PR TITLE
SO1S-421 노드 그룹 분리

### DIFF
--- a/apps/dev/app-image-updater.yaml
+++ b/apps/dev/app-image-updater.yaml
@@ -19,7 +19,7 @@ spec:
         tolerations:
           - key: kind
             operator: "Equal"
-            value: api
+            value: library
             effect: "NoSchedule"
 
         image:

--- a/apps/dev/app-sealed-secrets.yaml
+++ b/apps/dev/app-sealed-secrets.yaml
@@ -17,7 +17,7 @@ spec:
         tolerations:
           - key: kind
             operator: "Equal"
-            value: api
+            value: library
             effect: "NoSchedule"
 
   destination:

--- a/apps/prod/app-sealed-secrets.yaml
+++ b/apps/prod/app-sealed-secrets.yaml
@@ -17,7 +17,7 @@ spec:
         tolerations:
           - key: kind
             operator: "Equal"
-            value: api
+            value: library
             effect: "NoSchedule"
 
   destination:

--- a/charts/argocd/argocd-dev-values.yaml
+++ b/charts/argocd/argocd-dev-values.yaml
@@ -8,7 +8,7 @@ server:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
   ingress:
     enabled: false
@@ -25,21 +25,21 @@ controller:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 dex:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 redis:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 repoServer:
@@ -48,21 +48,21 @@ repoServer:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 applicationSet:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 notification:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 notifications:
@@ -71,5 +71,5 @@ notifications:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"

--- a/charts/argocd/argocd-prod-values.yaml
+++ b/charts/argocd/argocd-prod-values.yaml
@@ -8,7 +8,7 @@ server:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
   ingress:
     enabled: true
@@ -35,21 +35,21 @@ controller:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 dex:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 redis:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 repoServer:
@@ -58,21 +58,21 @@ repoServer:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 applicationSet:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 notification:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 notifications:
@@ -81,5 +81,5 @@ notifications:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"

--- a/charts/argocd/argocd-prod-values.yaml
+++ b/charts/argocd/argocd-prod-values.yaml
@@ -8,7 +8,7 @@ server:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
   ingress:
     enabled: true
@@ -35,21 +35,21 @@ controller:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 dex:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 redis:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 repoServer:
@@ -58,21 +58,21 @@ repoServer:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 applicationSet:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 notification:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 notifications:
@@ -81,5 +81,5 @@ notifications:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"

--- a/charts/backend/dev-values.yaml
+++ b/charts/backend/dev-values.yaml
@@ -21,7 +21,7 @@ autoscaling:
 tolerations:
   - key: kind
     operator: "Equal"
-    value: "api"
+    value: "application"
     effect: "NoSchedule"
 
 resourceQuota:
@@ -81,7 +81,7 @@ swagger:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
   ingress:
@@ -101,5 +101,5 @@ preInstall:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"

--- a/charts/backend/prod-values.yaml
+++ b/charts/backend/prod-values.yaml
@@ -21,7 +21,7 @@ autoscaling:
 tolerations:
   - key: kind
     operator: "Equal"
-    value: "api"
+    value: "application"
     effect: "NoSchedule"
 
 resourceQuota:
@@ -71,7 +71,7 @@ swagger:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
   ingress:
@@ -87,5 +87,5 @@ preInstall:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"

--- a/charts/frontend/dev-values.yaml
+++ b/charts/frontend/dev-values.yaml
@@ -30,5 +30,5 @@ ingress:
 tolerations:
   - key: kind
     operator: "Equal"
-    value: "api"
+    value: "application"
     effect: "NoSchedule"

--- a/charts/frontend/prod-values.yaml
+++ b/charts/frontend/prod-values.yaml
@@ -30,7 +30,7 @@ ingress:
 tolerations:
   - key: kind
     operator: "Equal"
-    value: "api"
+    value: "application"
     effect: "NoSchedule"
 
 podAnnotations: 

--- a/charts/istio/dev-values.yaml
+++ b/charts/istio/dev-values.yaml
@@ -9,7 +9,7 @@ istio-gateway:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 istiod:
@@ -17,12 +17,12 @@ istiod:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "library"
         effect: "NoSchedule"
 
 preInstall:
   tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "library"
         effect: "NoSchedule"

--- a/charts/istio/prod-values.yaml
+++ b/charts/istio/prod-values.yaml
@@ -21,7 +21,7 @@ istio-gateway:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "library"
       effect: "NoSchedule"
 
 istiod:
@@ -29,12 +29,12 @@ istiod:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "library"
         effect: "NoSchedule"
 
 preInstall:
   tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "library"
         effect: "NoSchedule"

--- a/charts/monitoring/dev-values.yaml
+++ b/charts/monitoring/dev-values.yaml
@@ -4,7 +4,7 @@ preInstall:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 ## Prometheus Configuration
@@ -14,7 +14,7 @@ prometheus:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "application"
         effect: "NoSchedule"
     routePrefix: /
     storageSpec:
@@ -360,7 +360,7 @@ alertmanager:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "application"
         effect: "NoSchedule"
   # service:
   #   type: LoadBalancer
@@ -383,21 +383,21 @@ thanosRuler:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "application"
         effect: "NoSchedule"
 prometheusOperator:
   logFormat: json
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
   admissionWebhooks:
     patch:
       tolerations:
         - key: kind
           operator: "Equal"
-          value: "api"
+          value: "application"
           effect: "NoSchedule"
 
 ## Grafana Configuration
@@ -407,7 +407,7 @@ grafana:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
   adminPassword: password1234
   service:
@@ -433,7 +433,7 @@ prometheus-node-exporter:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 ## kube-state-metrics Configuration
@@ -441,5 +441,5 @@ kube-state-metrics:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"

--- a/charts/monitoring/dev-values.yaml
+++ b/charts/monitoring/dev-values.yaml
@@ -4,7 +4,7 @@ preInstall:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 ## Prometheus Configuration
@@ -14,7 +14,7 @@ prometheus:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "application"
+        value: "library"
         effect: "NoSchedule"
     routePrefix: /
     storageSpec:
@@ -360,7 +360,7 @@ alertmanager:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "application"
+        value: "library"
         effect: "NoSchedule"
   # service:
   #   type: LoadBalancer
@@ -383,21 +383,21 @@ thanosRuler:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "application"
+        value: "library"
         effect: "NoSchedule"
 prometheusOperator:
   logFormat: json
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
   admissionWebhooks:
     patch:
       tolerations:
         - key: kind
           operator: "Equal"
-          value: "application"
+          value: "library"
           effect: "NoSchedule"
 
 ## Grafana Configuration
@@ -407,7 +407,7 @@ grafana:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
   adminPassword: password1234
   service:
@@ -433,7 +433,7 @@ prometheus-node-exporter:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 ## kube-state-metrics Configuration
@@ -441,5 +441,5 @@ kube-state-metrics:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"

--- a/charts/monitoring/prod-values.yaml
+++ b/charts/monitoring/prod-values.yaml
@@ -4,7 +4,7 @@ preInstall:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 ## Prometheus Configuration
@@ -14,7 +14,7 @@ prometheus:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "application"
+        value: "library"
         effect: "NoSchedule"
     routePrefix: /
     storageSpec:
@@ -360,7 +360,7 @@ alertmanager:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "application"
+        value: "library"
         effect: "NoSchedule"
   # service:
   #   type: LoadBalancer
@@ -383,21 +383,21 @@ thanosRuler:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "application"
+        value: "library"
         effect: "NoSchedule"
 prometheusOperator:
   logFormat: json
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
   admissionWebhooks:
     patch:
       tolerations:
         - key: kind
           operator: "Equal"
-          value: "application"
+          value: "library"
           effect: "NoSchedule"
 
 ## Grafana Configuration
@@ -407,7 +407,7 @@ grafana:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
   adminPassword: password1234
   service:
@@ -432,7 +432,7 @@ prometheus-node-exporter:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"
 
 ## kube-state-metrics Configuration
@@ -440,5 +440,5 @@ kube-state-metrics:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "application"
+      value: "library"
       effect: "NoSchedule"

--- a/charts/monitoring/prod-values.yaml
+++ b/charts/monitoring/prod-values.yaml
@@ -4,7 +4,7 @@ preInstall:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 ## Prometheus Configuration
@@ -14,7 +14,7 @@ prometheus:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "application"
         effect: "NoSchedule"
     routePrefix: /
     storageSpec:
@@ -360,7 +360,7 @@ alertmanager:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "application"
         effect: "NoSchedule"
   # service:
   #   type: LoadBalancer
@@ -383,21 +383,21 @@ thanosRuler:
     tolerations:
       - key: kind
         operator: "Equal"
-        value: "api"
+        value: "application"
         effect: "NoSchedule"
 prometheusOperator:
   logFormat: json
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
   admissionWebhooks:
     patch:
       tolerations:
         - key: kind
           operator: "Equal"
-          value: "api"
+          value: "application"
           effect: "NoSchedule"
 
 ## Grafana Configuration
@@ -407,7 +407,7 @@ grafana:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
   adminPassword: password1234
   service:
@@ -432,7 +432,7 @@ prometheus-node-exporter:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"
 
 ## kube-state-metrics Configuration
@@ -440,5 +440,5 @@ kube-state-metrics:
   tolerations:
     - key: kind
       operator: "Equal"
-      value: "api"
+      value: "application"
       effect: "NoSchedule"


### PR DESCRIPTION
# 노드 그룹 분리

이전에 작업한 PR과 동일합니다. 다시 올린 이유는 Infra가 머지되어야 Deploy도 머지하는게 맞아 다시 되돌리고 PR 올립니다

## Tasks


## Discussion

- 


## Jira

- 